### PR TITLE
[BACK-96] Fix bug in dbUpdater schedule

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - BACK-96
     paths:
       - 'packages/**'
       - '.github/workflows/**'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - BACK-96
     paths:
       - 'packages/**'
       - '.github/workflows/**'

--- a/packages/graphql_server/src/dbUpdater.ts
+++ b/packages/graphql_server/src/dbUpdater.ts
@@ -30,12 +30,12 @@ export const automaticDbUpdater = async () => {
   const currentDayOfWeek = currentDate.getDay()
 
   // Check if it's 4am on Sunday
-  if (currentHour === 4 && currentMinutes < 5 && currentDayOfWeek === 0) {
+  if (currentHour === 4 && currentDayOfWeek === 0) {
     await dailyDbUpdater(true)
     return
   }
   // Check if it's 4am on any other day of the week
-  if (currentHour === 4 && currentMinutes < 5) {
+  if (currentHour === 4) {
     await dailyDbUpdater(false)
     return
   }

--- a/packages/graphql_server/src/dbUpdater.ts
+++ b/packages/graphql_server/src/dbUpdater.ts
@@ -25,7 +25,6 @@ export const automaticDbUpdater = async () => {
   console.log('Auto-DB-updater run at', new Date().toLocaleString())
 
   const currentDate = new Date()
-  const currentMinutes = currentDate.getMinutes()
   const currentHour = currentDate.getHours()
   const currentDayOfWeek = currentDate.getDay()
 

--- a/packages/graphql_server/src/scraping/twitterScraping.ts
+++ b/packages/graphql_server/src/scraping/twitterScraping.ts
@@ -26,7 +26,7 @@ export async function getPostsForHashtag(hashtag: string): Promise<TwitterPost[]
 
     return mapToTwitterPosts(data.tweets)
   } catch (error) {
-    console.log(error)
+    console.log("Error while fetching Twitter posts for hashtag '" + hashtag + "'")
     return null
   }
 }

--- a/packages/graphql_server/src/updateProject.ts
+++ b/packages/graphql_server/src/updateProject.ts
@@ -287,7 +287,7 @@ const updateProjectStarHistory = async (repoName: string, owner: string) => {
   if (!(await repoIsAlreadyInDB(repoName, owner))) {
     return
   }
-  const MAX_NUMBER_OF_REQUESTS = 25 // this is also roughly the number of star history data points
+  const MAX_NUMBER_OF_REQUESTS = 10 // this is also roughly the number of star history data points
   try {
     const starHistory = await getRepoStarRecords(
       owner + '/' + repoName,


### PR DESCRIPTION
### Description of the issue
RepoJob schedule was adjusted in the last bug fix. But the dbUpdater has to be adjusted to that.

### How I implemented
- removed the sub 5 minute constraint in the if-else statements of the dbUpdater function
- also fixed rate limit bug. I reduced the amount of requests for star History from 25 to 10 and let the forkHistory be updated at 3am instead of 4am for everything else. This should allow for about ~300-400 active projects (trending or bookmarked) 

### Other
- deployed by adding BACK-96 to deploy.yml temporarily, so that the changes take effect right away, which is needed in this case
